### PR TITLE
Add aria labels to social links on home page

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -54,6 +54,7 @@ const Home = () => {
               target="_blank"
               rel="noopener noreferrer"
               className="text-gray-300 hover:text-purple-400 transition-colors"
+              aria-label="GitHub"
             >
               <Github className="h-8 w-8" />
             </a>
@@ -62,12 +63,14 @@ const Home = () => {
               target="_blank"
               rel="noopener noreferrer"
               className="text-gray-300 hover:text-purple-400 transition-colors"
+              aria-label="LinkedIn"
             >
               <Linkedin className="h-8 w-8" />
             </a>
             <a
               href="mailto:johan-willi@hotmail.com"
               className="text-gray-300 hover:text-purple-400 transition-colors"
+              aria-label="Correo electrónico"
             >
               <Mail className="h-8 w-8" />
             </a>


### PR DESCRIPTION
## Summary
- add aria-label attributes for GitHub, LinkedIn, and email links on the home page

## Testing
- `npm test` *(fails: useNavigate only in Router context, missing @testing-library/react-hooks)*
- `npm run lint`
- `npx pa11y dist/index.html` *(fails: libatk-1.0.so.0 missing)*
- `npx html-validate dist/index.html`

