### PR TITLE
🧹 [Fix unnecessary console.log in useLocalStorage hook]

### DIFF
--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -8,7 +8,7 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
       const item = window.localStorage.getItem(key);
       return item ? JSON.parse(item) : initialValue;
     } catch (error) {
-      console.log(error);
+      console.warn(`Error reading localStorage key "${key}":`, error);
       return initialValue;
     }
   });
@@ -22,7 +22,7 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
       setStoredValue(valueToStore);
       window.localStorage.setItem(key, JSON.stringify(valueToStore));
     } catch (error) {
-      console.log(error);
+      console.warn(`Error setting localStorage key "${key}":`, error);
     }
   };
 


### PR DESCRIPTION
🎯 **What:** Replaced `console.log` with `console.warn` inside the `catch` blocks in `src/hooks/useLocalStorage.ts`. Added descriptive context strings that include the `key` being accessed.

💡 **Why:** Silently swallowing errors with `console.log` makes debugging difficult when `localStorage` operations fail. By using `console.warn` and including the specific key, errors are more visible and actionable, while avoiding coupling this generic hook to domain-specific services like `ErrorService`.

✅ **Verification:** Verified by checking the `useLocalStorage.ts` implementation visually. Executed `pnpm test` (passed successfully) and `pnpm lint` (passed without new issues). Checked for any other similar occurrences in the hook and fixed them (the `setItem` catch block).

✨ **Result:** Better error reporting and maintainability for the `useLocalStorage` hook without breaking its fallback behavior.

---
*PR created automatically by Jules for task [14797914314782095042](https://jules.google.com/task/14797914314782095042) started by @Johanxd43*